### PR TITLE
LateNight: use button templates in samplers

### DIFF
--- a/res/skins/LateNight/sampler.xml
+++ b/res/skins/LateNight/sampler.xml
@@ -49,31 +49,17 @@
                 <Layout>horizontal</Layout>
                 <SizePolicy>min,min</SizePolicy>
                 <Children>
-                  <PushButton>
-                    <TooltipId>cue_gotoandplay_cue_default</TooltipId>
-                    <NumberStates>2</NumberStates>
-                    <State>
-                      <Number>0</Number>
-                      <Pressed>buttons/btn_play_sampler_down.svg</Pressed>
-                      <Unpressed>buttons/btn_play_sampler.svg</Unpressed>
-                    </State>
-                    <State>
-                      <Number>1</Number>
-                      <Pressed>buttons/btn_play_sampler_overdown.svg</Pressed>
-                      <Unpressed>buttons/btn_play_sampler_over.svg</Unpressed>
-                    </State>
-                    <Connection>
-                      <ConfigKey><Variable name="group"/>,cue_gotoandplay</ConfigKey>
-                      <ButtonState>LeftButton</ButtonState>
-                    </Connection>
-                    <Connection>
-                      <ConfigKey><Variable name="group"/>,cue_default</ConfigKey>
-                      <ButtonState>RightButton</ButtonState>
-                    </Connection>
-                    <Connection>
-                      <ConfigKey><Variable name="group"/>,play_indicator</ConfigKey>
-                    </Connection>
-                  </PushButton>
+                  <Template src="skin:button_2state_right_display.xml">
+                    <SetVariable name="TooltipId">cue_gotoandplay_cue_default</SetVariable>
+                    <SetVariable name="Size">34f,34f</SetVariable>
+                    <SetVariable name="state_0_pressed">play_sampler_down.svg</SetVariable>
+                    <SetVariable name="state_0_unpressed">play_sampler.svg</SetVariable>
+                    <SetVariable name="state_1_pressed">play_sampler_overdown.svg</SetVariable>
+                    <SetVariable name="state_1_unpressed">play_sampler_over.svg</SetVariable>
+                    <SetVariable name="ConfigKey"><Variable name="group"/>,cue_gotoandplay</SetVariable>
+                    <SetVariable name="ConfigKeyRight"><Variable name="group"/>,cue_default</SetVariable>
+                    <SetVariable name="ConfigKeyDisp"><Variable name="group"/>,play_indicator</SetVariable>
+                  </Template>
                 </Children>
               </WidgetGroup>
 
@@ -116,36 +102,18 @@
                     <Layout>horizontal</Layout>
                     <SizePolicy>min,min</SizePolicy>
                     <Children>
-                      <PushButton>
-                        <TooltipId>repeat</TooltipId>
-                        <NumberStates>2</NumberStates>
-                        <State>
-                          <Number>0</Number>
-                          <Pressed>buttons/btn_repeat.svg</Pressed>
-                          <Unpressed>buttons/btn_repeat.svg</Unpressed>
-                        </State>
-                        <State>
-                          <Number>1</Number>
-                          <Pressed>buttons/btn_repeat_over.svg</Pressed>
-                          <Unpressed>buttons/btn_repeat_over.svg</Unpressed>
-                        </State>
-                        <Connection>
-                          <ConfigKey><Variable name="group"/>,repeat</ConfigKey>
-                        </Connection>
-                      </PushButton>
-                      <PushButton>
-                        <TooltipId>eject</TooltipId>
-                        <NumberStates>1</NumberStates>
-                        <State>
-                          <Number>0</Number>
-                          <Pressed>buttons/btn_eject_sampler_over.svg</Pressed>
-                          <Unpressed>buttons/btn_eject_sampler.svg</Unpressed>
-                        </State>
-                        <Connection>
-                          <ConfigKey><Variable name="group"/>,eject</ConfigKey>
-                          <ButtonState>LeftButton</ButtonState>
-                        </Connection>
-                      </PushButton>
+                      <Template src="skin:button_2state_nohover.xml">
+                        <SetVariable name="TooltipId">repeat</SetVariable>
+                        <SetVariable name="icon">repeat</SetVariable>
+                        <SetVariable name="ConfigKey"><Variable name="group"/>,repeat</SetVariable>
+                        <SetVariable name="Size">25,18</SetVariable>
+                      </Template>
+                      <Template src="skin:button_2state_nohover.xml">
+                        <SetVariable name="TooltipId">eject</SetVariable>
+                        <SetVariable name="icon">eject</SetVariable>
+                        <SetVariable name="ConfigKey"><Variable name="group"/>,eject</SetVariable>
+                        <SetVariable name="Size">25,18</SetVariable>
+                      </Template>
                     </Children>
                   </WidgetGroup>
 
@@ -158,17 +126,17 @@
                         <NumberStates>3</NumberStates>
                         <State>
                           <Number>0</Number>
-                          <Pressed>buttons/btn_orientation_sampler_left.svg</Pressed>
+                          <Pressed scalemode="STRETCH_ASPECT">buttons/btn_orientation_sampler_left.svg</Pressed>
                           <Unpressed>buttons/btn_orientation_sampler_left.svg</Unpressed>
                         </State>
                         <State>
                           <Number>1</Number>
-                          <Pressed>buttons/btn_orientation_sampler_master.svg</Pressed>
+                          <Pressed scalemode="STRETCH_ASPECT">buttons/btn_orientation_sampler_master.svg</Pressed>
                           <Unpressed>buttons/btn_orientation_sampler_master.svg</Unpressed>
                         </State>
                         <State>
                           <Number>2</Number>
-                          <Pressed>buttons/btn_orientation_sampler_right.svg</Pressed>
+                          <Pressed scalemode="STRETCH_ASPECT">buttons/btn_orientation_sampler_right.svg</Pressed>
                           <Unpressed>buttons/btn_orientation_sampler_right.svg</Unpressed>
                         </State>
                         <Connection>
@@ -176,23 +144,12 @@
                           <ButtonState>LeftButton</ButtonState>
                         </Connection>
                       </PushButton>
-                      <PushButton>
-                        <TooltipId>keylock</TooltipId>
-                        <NumberStates>2</NumberStates>
-                        <State>
-                          <Number>0</Number>
-                          <Pressed>buttons/btn_keylock_sampler.svg</Pressed>
-                          <Unpressed>buttons/btn_keylock_sampler.svg</Unpressed>
-                        </State>
-                        <State>
-                          <Number>1</Number>
-                          <Pressed>buttons/btn_keylock_sampler_over.svg</Pressed>
-                          <Unpressed>buttons/btn_keylock_sampler_over.svg</Unpressed>
-                        </State>
-                        <Connection>
-                          <ConfigKey><Variable name="group"/>,keylock</ConfigKey>
-                        </Connection>
-                      </PushButton>
+                      <Template src="skin:button_2state_nohover.xml">
+                        <SetVariable name="TooltipId">keylock</SetVariable>
+                        <SetVariable name="icon">keylock</SetVariable>
+                        <SetVariable name="ConfigKey"><Variable name="group"/>,keylock</SetVariable>
+                        <SetVariable name="Size">25,18</SetVariable>
+                      </Template>
                     </Children>
                   </WidgetGroup>
                 </Children>
@@ -228,234 +185,41 @@
                 <Layout>horizontal</Layout>
                 <SizePolicy>min,min</SizePolicy>
                 <Children>
-                  <PushButton>
-                    <TooltipId>hotcue</TooltipId>
-                    <NumberStates>2</NumberStates>
-                    <LeftClickIsPushButton>true</LeftClickIsPushButton>
-                    <RightClickIsPushButton>true</RightClickIsPushButton>
-                    <State>
-                      <Number>0</Number>
-                      <Pressed>buttons/btn_hotcue_1_down.svg</Pressed>
-                      <Unpressed>buttons/btn_hotcue_1.svg</Unpressed>
-                    </State>
-                    <State>
-                      <Number>1</Number>
-                      <Pressed>buttons/btn_hotcue_1_overdown.svg</Pressed>
-                      <Unpressed>buttons/btn_hotcue_1_over.svg</Unpressed>
-                    </State>
-                    <Connection>
-                      <ConfigKey><Variable name="group"/>,hotcue_1_activate</ConfigKey>
-                      <ButtonState>LeftButton</ButtonState>
-                    </Connection>
-                    <Connection>
-                      <ConfigKey><Variable name="group"/>,hotcue_1_clear</ConfigKey>
-                      <ButtonState>RightButton</ButtonState>
-                    </Connection>
-                    <Connection>
-                      <ConfigKey><Variable name="group"/>,hotcue_1_enabled</ConfigKey>
-                    </Connection>
-                  </PushButton>
+                  <Template src="skin:button_hotcue.xml">
+                    <SetVariable name="number">1</SetVariable>
+                  </Template>
 
-                  <PushButton>
-                    <TooltipId>hotcue</TooltipId>
-                    <NumberStates>2</NumberStates>
-                    <LeftClickIsPushButton>true</LeftClickIsPushButton>
-                    <RightClickIsPushButton>true</RightClickIsPushButton>
-                    <State>
-                      <Number>0</Number>
-                      <Pressed>buttons/btn_hotcue_2_down.svg</Pressed>
-                      <Unpressed>buttons/btn_hotcue_2.svg</Unpressed>
-                    </State>
-                    <State>
-                      <Number>1</Number>
-                      <Pressed>buttons/btn_hotcue_2_overdown.svg</Pressed>
-                      <Unpressed>buttons/btn_hotcue_2_over.svg</Unpressed>
-                    </State>
-                    <Connection>
-                      <ConfigKey><Variable name="group"/>,hotcue_2_activate</ConfigKey>
-                      <ButtonState>LeftButton</ButtonState>
-                    </Connection>
-                    <Connection>
-                      <ConfigKey><Variable name="group"/>,hotcue_2_clear</ConfigKey>
-                      <ButtonState>RightButton</ButtonState>
-                    </Connection>
-                    <Connection>
-                      <ConfigKey><Variable name="group"/>,hotcue_2_enabled</ConfigKey>
-                    </Connection>
-                  </PushButton>
+                  <Template src="skin:button_hotcue.xml">
+                    <SetVariable name="number">2</SetVariable>
+                  </Template>
 
-                  <PushButton>
-                    <TooltipId>hotcue</TooltipId>
-                    <NumberStates>2</NumberStates>
-                    <LeftClickIsPushButton>true</LeftClickIsPushButton>
-                    <RightClickIsPushButton>true</RightClickIsPushButton>
-                    <State>
-                      <Number>0</Number>
-                      <Pressed>buttons/btn_hotcue_3_down.svg</Pressed>
-                      <Unpressed>buttons/btn_hotcue_3.svg</Unpressed>
-                    </State>
-                    <State>
-                      <Number>1</Number>
-                      <Pressed>buttons/btn_hotcue_3_overdown.svg</Pressed>
-                      <Unpressed>buttons/btn_hotcue_3_over.svg</Unpressed>
-                    </State>
-                    <Connection>
-                      <ConfigKey><Variable name="group"/>,hotcue_3_activate</ConfigKey>
-                      <ButtonState>LeftButton</ButtonState>
-                    </Connection>
-                    <Connection>
-                      <ConfigKey><Variable name="group"/>,hotcue_3_clear</ConfigKey>
-                      <ButtonState>RightButton</ButtonState>
-                    </Connection>
-                    <Connection>
-                      <ConfigKey><Variable name="group"/>,hotcue_3_enabled</ConfigKey>
-                    </Connection>
-                  </PushButton>
+                  <Template src="skin:button_hotcue.xml">
+                    <SetVariable name="number">3</SetVariable>
+                  </Template>
 
-                  <PushButton>
-                    <TooltipId>hotcue</TooltipId>
-                    <NumberStates>2</NumberStates>
-                    <LeftClickIsPushButton>true</LeftClickIsPushButton>
-                    <RightClickIsPushButton>true</RightClickIsPushButton>
-                    <State>
-                      <Number>0</Number>
-                      <Pressed>buttons/btn_hotcue_4_down.svg</Pressed>
-                      <Unpressed>buttons/btn_hotcue_4.svg</Unpressed>
-                    </State>
-                    <State>
-                      <Number>1</Number>
-                      <Pressed>buttons/btn_hotcue_4_overdown.svg</Pressed>
-                      <Unpressed>buttons/btn_hotcue_4_over.svg</Unpressed>
-                    </State>
-                    <Connection>
-                      <ConfigKey><Variable name="group"/>,hotcue_4_activate</ConfigKey>
-                      <ButtonState>LeftButton</ButtonState>
-                    </Connection>
-                    <Connection>
-                      <ConfigKey><Variable name="group"/>,hotcue_4_clear</ConfigKey>
-                      <ButtonState>RightButton</ButtonState>
-                    </Connection>
-                    <Connection>
-                      <ConfigKey><Variable name="group"/>,hotcue_4_enabled</ConfigKey>
-                    </Connection>
-                  </PushButton>
+                  <Template src="skin:button_hotcue.xml">
+                    <SetVariable name="number">4</SetVariable>
+                  </Template>
 
                   <WidgetGroup><!-- /Hotcues 5-8 -->
                     <Layout>horizontal</Layout>
                     <SizePolicy>min,min</SizePolicy>
                     <Children>
+                      <Template src="skin:button_hotcue.xml">
+                        <SetVariable name="number">5</SetVariable>
+                      </Template>
 
-                      <PushButton>
-                        <TooltipId>hotcue</TooltipId>
-                        <NumberStates>2</NumberStates>
-                        <LeftClickIsPushButton>true</LeftClickIsPushButton>
-                        <RightClickIsPushButton>true</RightClickIsPushButton>
-                        <State>
-                          <Number>0</Number>
-                          <Pressed>buttons/btn_hotcue_5_down.svg</Pressed>
-                          <Unpressed>buttons/btn_hotcue_5.svg</Unpressed>
-                        </State>
-                        <State>
-                          <Number>1</Number>
-                          <Pressed>buttons/btn_hotcue_5_overdown.svg</Pressed>
-                          <Unpressed>buttons/btn_hotcue_5_over.svg</Unpressed>
-                        </State>
-                        <Connection>
-                          <ConfigKey><Variable name="group"/>,hotcue_5_activate</ConfigKey>
-                          <ButtonState>LeftButton</ButtonState>
-                        </Connection>
-                        <Connection>
-                          <ConfigKey><Variable name="group"/>,hotcue_5_clear</ConfigKey>
-                          <ButtonState>RightButton</ButtonState>
-                        </Connection>
-                        <Connection>
-                          <ConfigKey><Variable name="group"/>,hotcue_5_enabled</ConfigKey>
-                        </Connection>
-                      </PushButton>
+                      <Template src="skin:button_hotcue.xml">
+                        <SetVariable name="number">6</SetVariable>
+                      </Template>
 
-                      <PushButton>
-                        <TooltipId>hotcue</TooltipId>
-                        <NumberStates>2</NumberStates>
-                        <LeftClickIsPushButton>true</LeftClickIsPushButton>
-                        <RightClickIsPushButton>true</RightClickIsPushButton>
-                        <State>
-                          <Number>0</Number>
-                          <Pressed>buttons/btn_hotcue_6_down.svg</Pressed>
-                          <Unpressed>buttons/btn_hotcue_6.svg</Unpressed>
-                        </State>
-                        <State>
-                          <Number>1</Number>
-                          <Pressed>buttons/btn_hotcue_6_overdown.svg</Pressed>
-                          <Unpressed>buttons/btn_hotcue_6_over.svg</Unpressed>
-                        </State>
-                        <Connection>
-                          <ConfigKey><Variable name="group"/>,hotcue_6_activate</ConfigKey>
-                          <ButtonState>LeftButton</ButtonState>
-                        </Connection>
-                        <Connection>
-                          <ConfigKey><Variable name="group"/>,hotcue_6_clear</ConfigKey>
-                          <ButtonState>RightButton</ButtonState>
-                        </Connection>
-                        <Connection>
-                          <ConfigKey><Variable name="group"/>,hotcue_6_enabled</ConfigKey>
-                        </Connection>
-                      </PushButton>
+                      <Template src="skin:button_hotcue.xml">
+                        <SetVariable name="number">7</SetVariable>
+                      </Template>
 
-                      <PushButton>
-                        <TooltipId>hotcue</TooltipId>
-                        <NumberStates>2</NumberStates>
-                        <LeftClickIsPushButton>true</LeftClickIsPushButton>
-                        <RightClickIsPushButton>true</RightClickIsPushButton>
-                        <State>
-                          <Number>0</Number>
-                          <Pressed>buttons/btn_hotcue_7_down.svg</Pressed>
-                          <Unpressed>buttons/btn_hotcue_7.svg</Unpressed>
-                        </State>
-                        <State>
-                          <Number>1</Number>
-                          <Pressed>buttons/btn_hotcue_7_overdown.svg</Pressed>
-                          <Unpressed>buttons/btn_hotcue_7_over.svg</Unpressed>
-                        </State>
-                        <Connection>
-                          <ConfigKey><Variable name="group"/>,hotcue_7_activate</ConfigKey>
-                          <ButtonState>LeftButton</ButtonState>
-                        </Connection>
-                        <Connection>
-                          <ConfigKey><Variable name="group"/>,hotcue_7_clear</ConfigKey>
-                          <ButtonState>RightButton</ButtonState>
-                        </Connection>
-                        <Connection>
-                          <ConfigKey><Variable name="group"/>,hotcue_7_enabled</ConfigKey>
-                        </Connection>
-                      </PushButton>
-
-                      <PushButton>
-                        <TooltipId>hotcue</TooltipId>
-                        <NumberStates>2</NumberStates>
-                        <LeftClickIsPushButton>true</LeftClickIsPushButton>
-                        <RightClickIsPushButton>true</RightClickIsPushButton>
-                        <State>
-                          <Number>0</Number>
-                          <Pressed>buttons/btn_hotcue_8_down.svg</Pressed>
-                          <Unpressed>buttons/btn_hotcue_8.svg</Unpressed>
-                        </State>
-                        <State>
-                          <Number>1</Number>
-                          <Pressed>buttons/btn_hotcue_8_overdown.svg</Pressed>
-                          <Unpressed>buttons/btn_hotcue_8_over.svg</Unpressed>
-                        </State>
-                        <Connection>
-                          <ConfigKey><Variable name="group"/>,hotcue_8_activate</ConfigKey>
-                          <ButtonState>LeftButton</ButtonState>
-                        </Connection>
-                        <Connection>
-                          <ConfigKey><Variable name="group"/>,hotcue_8_clear</ConfigKey>
-                          <ButtonState>RightButton</ButtonState>
-                        </Connection>
-                        <Connection>
-                          <ConfigKey><Variable name="group"/>,hotcue_8_enabled</ConfigKey>
-                        </Connection>
-                      </PushButton>
+                      <Template src="skin:button_hotcue.xml">
+                        <SetVariable name="number">8</SetVariable>
+                      </Template>
                     </Children>
                     <Connection>
                       <ConfigKey persist="true">[Skin],8_hotcues</ConfigKey>
@@ -474,23 +238,12 @@
                 <Layout>horizontal</Layout>
                 <SizePolicy>min,min</SizePolicy>
                 <Children>
-                  <PushButton>
-                    <TooltipId>pfl</TooltipId>
-                    <NumberStates>2</NumberStates>
-                    <State>
-                      <Number>0</Number>
-                      <Pressed>buttons/btn_pfl_down.svg</Pressed>
-                      <Unpressed>buttons/btn_pfl.svg</Unpressed>
-                    </State>
-                    <State>
-                      <Number>1</Number>
-                      <Pressed>buttons/btn_pfl_overdown.svg</Pressed>
-                      <Unpressed>buttons/btn_pfl_over.svg</Unpressed>
-                    </State>
-                    <Connection>
-                      <ConfigKey><Variable name="group"/>,pfl</ConfigKey>
-                    </Connection>
-                  </PushButton>
+                  <Template src="skin:button_2state.xml">
+                    <SetVariable name="TooltipId">pfl</SetVariable>
+                    <SetVariable name="icon">pfl</SetVariable>
+                    <SetVariable name="ConfigKey"><Variable name="group"/>,pfl</SetVariable>
+                    <SetVariable name="Size">26,26</SetVariable>
+                  </Template>
                 </Children>
               </WidgetGroup><!-- /SamplerPfl -->
 
@@ -563,23 +316,13 @@
             <Layout>horizontal</Layout>
             <SizePolicy>min,min</SizePolicy>
             <Children>
-              <PushButton>
-                <TooltipId>beatsync_beatsync_tempo</TooltipId>
-                <NumberStates>1</NumberStates>
-                <State>
-                  <Number>0</Number>
-                  <Pressed>buttons/btn_sync_sampler_overdown.svg</Pressed>
-                  <Unpressed>buttons/btn_sync_sampler.svg</Unpressed>
-                </State>
-                <Connection>
-                  <ConfigKey><Variable name="group"/>,beatsync</ConfigKey>
-                  <ButtonState>LeftButton</ButtonState>
-                </Connection>
-                <Connection>
-                  <ConfigKey><Variable name="group"/>,beatsync_tempo</ConfigKey>
-                  <ButtonState>RightButton</ButtonState>
-                </Connection>
-              </PushButton>
+              <Template src="skin:button_1state_right.xml">
+                <SetVariable name="TooltipId">beatsync_beatsync_tempo</SetVariable>
+                <SetVariable name="state_0_pressed">sync_sampler_overdown.svg</SetVariable>
+                <SetVariable name="state_0_unpressed">sync_sampler.svg</SetVariable>
+                <SetVariable name="ConfigKey"><Variable name="group"/>,beatsync</SetVariable>
+                <SetVariable name="ConfigKeyRight"><Variable name="group"/>,beatsync_tempo</SetVariable>
+              </Template>
             </Children>
           </WidgetGroup>
         </Children>

--- a/res/skins/LateNight/samplers_rack.xml
+++ b/res/skins/LateNight/samplers_rack.xml
@@ -15,12 +15,12 @@
             <NumberStates>2</NumberStates>
             <State>
               <Number>0</Number>
-              <Pressed>skin:/buttons/btn_samplerExpand.svg</Pressed>
+              <Pressed scalemode="STRETCH_ASPECT">skin:/buttons/btn_samplerExpand.svg</Pressed>
               <Unpressed>skin:/buttons/btn_samplerExpand.svg</Unpressed>
             </State>
             <State>
               <Number>1</Number>
-              <Pressed>skin:/buttons/btn_samplerCollapse.svg</Pressed>
+              <Pressed scalemode="STRETCH_ASPECT">skin:/buttons/btn_samplerCollapse.svg</Pressed>
               <Unpressed>skin:/buttons/btn_samplerCollapse.svg</Unpressed>
             </State>
             <Connection>

--- a/res/skins/LateNight/samplersmall.xml
+++ b/res/skins/LateNight/samplersmall.xml
@@ -11,31 +11,17 @@
         <Layout>horizontal</Layout>
         <SizePolicy>min,min</SizePolicy>
         <Children>
-          <PushButton>
-            <TooltipId>cue_gotoandplay_cue_default</TooltipId>
-            <NumberStates>2</NumberStates>
-            <State>
-              <Number>0</Number>
-              <Pressed>buttons/btn_play_sampler_down.svg</Pressed>
-              <Unpressed>buttons/btn_play_sampler.svg</Unpressed>
-            </State>
-            <State>
-              <Number>1</Number>
-              <Pressed>buttons/btn_play_sampler_overdown.svg</Pressed>
-              <Unpressed>buttons/btn_play_sampler_over.svg</Unpressed>
-            </State>
-            <Connection>
-              <ConfigKey><Variable name="group"/>,cue_gotoandplay</ConfigKey>
-              <ButtonState>LeftButton</ButtonState>
-            </Connection>
-            <Connection>
-              <ConfigKey><Variable name="group"/>,cue_default</ConfigKey>
-              <ButtonState>RightButton</ButtonState>
-            </Connection>
-            <Connection>
-              <ConfigKey><Variable name="group"/>,play_indicator</ConfigKey>
-            </Connection>
-          </PushButton>
+          <Template src="skin:button_2state_right_display.xml">
+            <SetVariable name="TooltipId">cue_gotoandplay_cue_default</SetVariable>
+            <SetVariable name="Size">34f,34f</SetVariable>
+            <SetVariable name="state_0_pressed">play_sampler_down.svg</SetVariable>
+            <SetVariable name="state_0_unpressed">play_sampler.svg</SetVariable>
+            <SetVariable name="state_1_pressed">play_sampler_overdown.svg</SetVariable>
+            <SetVariable name="state_1_unpressed">play_sampler_over.svg</SetVariable>
+            <SetVariable name="ConfigKey"><Variable name="group"/>,cue_gotoandplay</SetVariable>
+            <SetVariable name="ConfigKeyRight"><Variable name="group"/>,cue_default</SetVariable>
+            <SetVariable name="ConfigKeyDisp"><Variable name="group"/>,play_indicator</SetVariable>
+          </Template>
         </Children>
       </WidgetGroup>
 
@@ -104,37 +90,19 @@
                 </Connection>
               </PushButton>
 
-              <PushButton>
-                <TooltipId>keylock</TooltipId>
-                <NumberStates>2</NumberStates>
-                <State>
-                  <Number>0</Number>
-                  <Pressed>buttons/btn_keylock_sampler.svg</Pressed>
-                  <Unpressed>buttons/btn_keylock_sampler.svg</Unpressed>
-                </State>
-                <State>
-                  <Number>1</Number>
-                  <Pressed>buttons/btn_keylock_sampler_over.svg</Pressed>
-                  <Unpressed>buttons/btn_keylock_sampler_over.svg</Unpressed>
-                </State>
-                <Connection>
-                  <ConfigKey><Variable name="group"/>,keylock</ConfigKey>
-                </Connection>
-              </PushButton>
+              <Template src="skin:button_2state_nohover.xml">
+                <SetVariable name="TooltipId">keylock</SetVariable>
+                <SetVariable name="icon">keylock</SetVariable>
+                <SetVariable name="ConfigKey"><Variable name="group"/>,keylock</SetVariable>
+                <SetVariable name="Size">21,18</SetVariable>
+              </Template>
 
-              <PushButton>
-                <TooltipId>eject</TooltipId>
-                <NumberStates>1</NumberStates>
-                <State>
-                  <Number>0</Number>
-                  <Pressed>buttons/btn_eject_sampler_over.svg</Pressed>
-                  <Unpressed>buttons/btn_eject_sampler.svg</Unpressed>
-                </State>
-                <Connection>
-                  <ConfigKey><Variable name="group"/>,eject</ConfigKey>
-                  <ButtonState>LeftButton</ButtonState>
-                </Connection>
-              </PushButton>
+              <Template src="skin:button_2state_nohover.xml">
+                <SetVariable name="TooltipId">eject</SetVariable>
+                <SetVariable name="icon">eject</SetVariable>
+                <SetVariable name="ConfigKey"><Variable name="group"/>,eject</SetVariable>
+                <SetVariable name="Size">21,18</SetVariable>
+              </Template>
 
               <WidgetGroup><SizePolicy>me,min</SizePolicy></WidgetGroup>
 


### PR DESCRIPTION
fixes scaling with high pixel density screens (the templates use
scalemode="STRETCH_ASPECT"). I do not know why setting
scalemode="STRETCH_ASPECT" for the crossfader assignment and
sampler expansion <Unpressed> elements does not work.